### PR TITLE
Improve Laravel 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php" : "~5.6|^7.0",
-        "illuminate/filesystem": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || 6.0.*",
+        "illuminate/filesystem": "^5.0 || ^6.0",
         "league/flysystem-webdav": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 6 uses Semver, which means the minor version (6.X) will change often. illuminate/filesystem is kept up-to-date and uses the same version number as laravel/framework.

This syntax (^6.0) means "at least 6.0, but less than 7.0". It should allow forward compatibility with Laravel 6 for a few months.