### PR TITLE
add authType to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Create a webdav filesystem disk:
 	...
 ];
 ```
+### Authentication
+The authentication method is determined by ‍`authType` in the configuration:
+
+Example with basic authentication:
+``` php
+'webdav' => [
+    ...
+    'authType' => 1,
+],
+```
 
 ## Change log
 


### PR DESCRIPTION
I got errors when trying to upload with basic authentication and it was fixed by adding the `authType` that I found in #10  and described in https://stackoverflow.com/questions/72365649/necessary-data-rewind-wasnt-possible-with-webdav so I added to the documentation.